### PR TITLE
Various AppStream metadata fixes

### DIFF
--- a/ua.org.brezblock.q4wine.appdata.xml
+++ b/ua.org.brezblock.q4wine.appdata.xml
@@ -5,7 +5,7 @@
 
   <name>q4wine</name>
   <summary>Utility for Wine applications and prefixes management</summary>
-  <summary xml:lang="cz">užitečný program pro programy wine a správu předpon</summary>
+  <summary xml:lang="cs">Užitečný program pro správu Wine aplikací a prefixů</summary>
   <summary xml:lang="de">Werkzeug zur Verwaltung der Wine-Anwendungen und -Präfixe</summary>
   <summary xml:lang="en">Utility for Wine applications and prefixes management</summary>
   <summary xml:lang="es">Utilidad para el manejo de aplicaciones y prefijos de wine</summary>
@@ -20,7 +20,7 @@
 
   <description>
     <p>
-      Q4Wine is a Qt GUI for W.I.N.E. It will help you manage wine prefixes and installed applications.
+      Q4Wine is a Qt GUI for Wine. It will help you manage Wine prefixes and installed applications.
     </p>
   </description>
 


### PR DESCRIPTION
1. Lang "cz" is incorrect, the correct one for Czech is "cs",
2. fix typos in Czech summary by using the actual one from upstream desktop file,
3. it's "Wine", not "W.I.N.E.".