### PR TITLE
Remove org.winehq.Wine.DLL reference

### DIFF
--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -45,7 +45,6 @@ inherit-extensions:
   - org.freedesktop.Platform.ffmpeg-full
   - org.freedesktop.Platform.GL32
   - org.freedesktop.Platform.VAAPI.Intel.i386
-  - org.winehq.Wine.DLLs
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
 add-extensions:


### PR DESCRIPTION
This extension is broken and discontinued, see https://github.com/flathub/org.winehq.Wine/issues/154