### PR TITLE
[beta] Sync with master and use wine-wow64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-  "only-arches": ["x86_64"],
-  "automerge-flathubbot-prs": true
+  "only-arches": ["x86_64"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "automerge-flathubbot-prs": true
 }

--- a/fuse-closefrom.patch
+++ b/fuse-closefrom.patch
@@ -1,0 +1,20 @@
+diff --git a/util/ulockmgr_server.c b/util/ulockmgr_server.c
+index 273c7d923..a04dac5c6 100644
+--- a/util/ulockmgr_server.c
++++ b/util/ulockmgr_server.c
+@@ -124,6 +128,7 @@ static int receive_message(int sock, void *buf, size_t buflen, int *fdp,
+ 	return res;
+ }
+ 
++#if 0
+ static int closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+@@ -141,6 +146,7 @@ static int closefrom(int minfd)
+ 	}
+ 	return 0;
+ }
++#endif
+ 
+ static void send_reply(int cfd, struct message *msg)
+ {

--- a/ua.org.brezblock.q4wine.appdata.xml
+++ b/ua.org.brezblock.q4wine.appdata.xml
@@ -5,13 +5,22 @@
 
   <name>q4wine</name>
   <summary>Utility for Wine applications and prefixes management</summary>
-  <summary xml:lang="cs">Užitečný program pro správu Wine aplikací a prefixů</summary>
-  <summary xml:lang="de">Werkzeug zur Verwaltung der Wine-Anwendungen und -Präfixe</summary>
+  <summary xml:lang="cs">Užitečný program pro programy Wine a správu předpon</summary>
+  <summary xml:lang="de">Werkzeug zur Verwaltung von Wine-Anwendungen und Präfixen</summary>
   <summary xml:lang="en">Utility for Wine applications and prefixes management</summary>
-  <summary xml:lang="es">Utilidad para el manejo de aplicaciones y prefijos de wine</summary>
-  <summary xml:lang="it">Programma per gestire le applicazioni con Wine e i prefissi</summary>
-  <summary xml:lang="ru">Программа для настройки приложений и управления префиксами Wine</summary>
+  <summary xml:lang="es">Utilidad para el manejo de aplicaciones y prefijos de Wine</summary>
+  <summary xml:lang="it">Programma per gestire le applicazioni e i prefissi di Wine</summary>
   <summary xml:lang="uk">Програма для налаштування програм та керування префіксами Wine</summary>
+  <summary xml:lang="fa">>برنامه ای برای مدیریت پیشوند ها و برنامه های اجرا شونده تحت شراب.</summary>
+  <summary xml:lang="he">כלי לניהול יישומים וקידומות של Wine.</summary>
+  <summary xml:lang="zh_CN">用于 Wine 应用程序与前缀的管理实用程序。</summary>
+  <summary xml:lang="nl">Een hulpprogramma voor Wine-programma- en profielbeheer</summary>
+  <summary xml:lang="af">Nutsprogram vir Wine programmatuur en om Wine-tuistes te bestuur</summary>
+  <summary xml:lang="pl">Zarządzanie programami Wine i prefiksami</summary>
+  <summary xml:lang="fr">Utilitaire pour la gestion des préfixes et des applications Wine</summary>
+  <summary xml:lang="pt_BR">Utilitário para gerência de prefixos e programas do Wine</summary>
+  <summary xml:lang="ja.ts">Wine 上のアプリケーションと実行環境を管理するユーティリティです。</summary>
+  <summary xml:lang="zh_TW">Wine 應用程式與前綴管理的實用工具。</summary>
 
   <translation type="qt">q4wine/l10n/q4wine</translation>
 
@@ -42,6 +51,9 @@
   <developer_name>Oleksii S. Malakhov</developer_name>
 
   <releases>
+    <release version="1.4.2" date="2025-04-28" />
+    <release version="1.4.1" date="2025-04-19" />
+    <release version="1.4.0" date="2025-04-13" />
     <release version="1.3.13" date="2020-09-10" />
     <release version="1.3.12" date="2020-02-08" />
     <release version="1.3.11" date="2019-01-02" />

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -131,6 +131,8 @@ modules:
       - ln -srv /app/{utils/,}share/vulkan/implicit_layer.d
       - install -Dm755 pkexec.sh /app/bin/pkexec
       - install -Dm755 sudo.sh /app/bin/sudo
+      - ln -s /usr/bin/false /app/bin/mount
+      - ln -s /usr/bin/false /app/bin/umount
     sources:
       - type: script
         dest-filename: pkexec.sh

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -1,9 +1,9 @@
 id: ua.org.brezblock.q4wine
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 base: org.winehq.Wine
-base-version: stable-21.08
+base-version: stable-22.08
 command: q4wine
 rename-icon: q4wine
 rename-desktop-file: q4wine.desktop

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -32,6 +32,11 @@ finish-args:
 cleanup:
   - '*.a'
   - '*.la'
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /lib32/cmake
+  - /lib32/pkgconfig
   - /share/doc
   - /share/man
 inherit-extensions:

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -87,6 +87,7 @@ modules:
               env:
                 MOUNT_FUSE_PATH: /app/bin
                 INIT_D_PATH: /app/etc/init.d
+                UDEV_RULES_PATH: /app/etc/udev/rules.d
             sources:
               - type: archive
                 url: https://github.com/libfuse/libfuse/archive/fuse-2.9.9.tar.gz

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -71,6 +71,11 @@ modules:
         commit: 6b9831ce41841b1e08fa43f7214f3829b8952171
       - type: file
         path: ua.org.brezblock.q4wine.appdata.xml
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/brezerk/q4wine/releases/latest
+          tag-query: .tag_name
+          timestamp-query: .published_at
     modules:
 
       - name: fuseiso

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -1,9 +1,9 @@
 id: ua.org.brezblock.q4wine
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-22.08
+runtime-version: 5.15-23.08
 base: org.winehq.Wine
-base-version: stable-22.08
+base-version: stable-23.08
 command: q4wine
 rename-icon: q4wine
 rename-desktop-file: q4wine.desktop

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -94,6 +94,9 @@ modules:
               - type: shell
                 commands:
                   - ./makeconf.sh
+              - type: patch
+                paths:
+                  - fuse-closefrom.patch
             cleanup:
               - /etc
               - /include

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -1,9 +1,9 @@
 id: ua.org.brezblock.q4wine
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-23.08
+runtime-version: 5.15-24.08
 base: org.winehq.Wine
-base-version: stable-23.08
+base-version: stable-24.08
 command: q4wine
 rename-icon: q4wine
 rename-desktop-file: q4wine.desktop

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -45,7 +45,6 @@ inherit-extensions:
   - org.freedesktop.Platform.ffmpeg-full
   - org.freedesktop.Platform.GL32
   - org.freedesktop.Platform.VAAPI.Intel.i386
-  - org.winehq.Wine.DLLs
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
 add-extensions:

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -3,7 +3,7 @@ runtime: org.kde.Platform
 sdk: org.kde.Sdk
 runtime-version: 6.9
 base: org.winehq.Wine
-base-version: stable-24.08
+base-version: wow64-24.08
 command: q4wine
 rename-icon: q4wine
 rename-desktop-file: q4wine.desktop
@@ -11,7 +11,7 @@ finish-args:
   - --allow=devel # For Wine crash handling
   - --allow=multiarch
   - --device=all
-  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib32/gstreamer-1.0:/app/lib/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0
   - --env=WINEDLLPATH=/app/dlls/lib32:/app/dlls/lib:/app/lib32/wine/wined3d:/app/lib/wine/wined3d
   - --env=WINEPREFIX=/var/data/wine
   - --filesystem=xdg-desktop
@@ -40,13 +40,9 @@ cleanup:
   - /share/doc
   - /share/man
 inherit-extensions:
-  - org.freedesktop.Platform.Compat.i386
-  - org.freedesktop.Platform.ffmpeg_full.i386
   - org.freedesktop.Platform.ffmpeg-full
-  - org.freedesktop.Platform.GL32
-  - org.freedesktop.Platform.VAAPI.Intel.i386
-  - org.winehq.Wine.gecko
-  - org.winehq.Wine.mono
+  - org.winehq.Wine.gecko-wow64
+  - org.winehq.Wine.mono-wow64
 add-extensions:
   com.valvesoftware.Steam.Utility:
     subdirectories: true

--- a/ua.org.brezblock.q4wine.yml
+++ b/ua.org.brezblock.q4wine.yml
@@ -1,7 +1,7 @@
 id: ua.org.brezblock.q4wine
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-24.08
+runtime-version: 6.9
 base: org.winehq.Wine
 base-version: stable-24.08
 command: q4wine
@@ -71,8 +71,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/brezerk/q4wine.git
-        tag: v1.3.13
-        commit: 6b9831ce41841b1e08fa43f7214f3829b8952171
+        tag: v1.4.2
+        commit: f506d89976c427d4878ac968db448bf7dd8cdbe2
       - type: file
         path: ua.org.brezblock.q4wine.appdata.xml
         x-checker-data:
@@ -122,14 +122,14 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://github.com/KDE/konsole/archive/v22.04.3.tar.gz
-        sha256: 603e5961d4ddde3bb3193941667ce387c878e6862684d78e9bc7fecea1bc3c34
+        url: https://github.com/KDE/konsole/archive/refs/tags/v25.04.0.tar.gz
+        sha256: 8112dddd00576d5ec2d2eb9eee8dad3f2ab59a6b168f3beb4abb17c6d8c2daf3
     cleanup:
       - /share/applications
       - /share/khotkeys
-      - /share/knotifications5
-      - /share/kservices5
-      - /share/kservicetypes5
+      - /share/knotifications6
+      - /share/kservices6
+      - /share/kservicetypes6
       - /share/metainfo
 
   - name: q4wine-app-environment


### PR DESCRIPTION
This syncs changes with current master and also utilizes wine-wow64 baseapp. It allows to run 32-bit windows software on native 64-bit linux thus avoiding installation of 32-bit runtime, wine and dependencies.

After merge users can experiment with it through flathub-beta.